### PR TITLE
update: new entries in games-direct

### DIFF
--- a/other/games-direct.yaml
+++ b/other/games-direct.yaml
@@ -162,3 +162,9 @@ payload:
   # FaceIT website
   - DOMAIN-SUFFIX,faceit.com
   - DOMAIN-SUFFIX,faceit-cdn.net
+
+  # CyberShoke
+  - DOMAIN-SUFFIX,cybershoke.net
+
+  # MIMESIS
+  - PROCESS-NAME,MIMESIS.exe


### PR DESCRIPTION
This pull request adds new rules to the `other/games-direct.yaml` file to support additional gaming services. The changes expand the list of domain and process-based rules to include CyberShoke and MIMESIS.

New gaming service rules:

* Added a domain rule for `cybershoke.net` to support CyberShoke.
* Added a process rule for `MIMESIS.exe` to support MIMESIS.