### PR TITLE
feat: add VALORANT ports and missing processes to direct routing rules

### DIFF
--- a/other/games-direct.yaml
+++ b/other/games-direct.yaml
@@ -78,7 +78,12 @@ payload:
   - PROCESS-NAME,Quaver.exe
 
   # Valorant
-  - PROCESS-NAME,VALORANT-Win64-Shipping.exe
+  - PROCESS-NAME,VALORANT-Win64-Shipping.exe         # Game
+  - PROCESS-NAME,VALORANT.exe                        # VALORANT Launcher
+  - PROCESS-NAME,RiotClientservices.exe              # Riot Customer Service
+  - DST-PORT,2099,5222-5223,8088,8393-8400,8443,8446 # TCP: PVP.Net (2099,5222-5223), Installer/Maestro (8393-8400), Vanguard (8443), Client connections (8446)
+  - DST-PORT,5000-5500,8088,8180-8181                # UDP: Game client (5000-5500), Spectator (8088), Voice chat (8180-8181)
+  - DST-PORT,7000-8000,27016-27024,54000-54012       # UDP: Additional game traffic (7000-8000), Server connections (27016-27024, 54000-54012)
 
   # Escape from Tarkov
   - PROCESS-NAME,BsgLauncher.exe # EFT Launcher


### PR DESCRIPTION
## What does this PR do?
Adds missing process names and network ports for VALORANT to the `games-direct.yaml` routing rules.

## Why is this needed?
The existing process‑name (`PROCESS-NAME`) rules were not sufficient to catch all VALORANT traffic. As a result, many game connections (voice chat, matchmaking, anti‑cheat heartbeats, etc.) were still being routed through the proxy, causing unplayable latency and high ping. Additionally, downloading match replays was impossible, because they would hang indefinitely and never load

Adding explicit TCP/UDP port rules ensures that **all** VALORANT‑related traffic bypasses the proxy, regardless of how the connection is established.

## What was changed?
- Added process rules for `VALORANT.exe` (launcher) and `RiotClientservices.exe` (background service)
- Added explicit **TCP** port rules:
  - `2099`, `5222-5223` — PVP.Net (login, chat)
  - `8088` — Spectator mode
  - `8393-8400` — Installer and Master (patcher/maestro)
  - `8443` — Riot Vanguard
  - `8446` — Client connections
- Added explicit **UDP** port ranges:
  - `5000-5500` — Gameplay and voice (critical)
  - `7000-8000` — Game client
  - `8088` — Spectator mode
  - `8180-8181` — Voice chat
  - `27016-27024`, `54000-54012` — Server connections (Asia Pacific and other regions)